### PR TITLE
Remove a Hosts element to workaround sideload failure on Old Outlook

### DIFF
--- a/manifest.outlook.xml
+++ b/manifest.outlook.xml
@@ -39,11 +39,6 @@
     <Rule xsi:type="ItemIs" ItemType="Message" FormType="Read" />
   </Rule>
   <VersionOverrides xmlns="http://schemas.microsoft.com/office/mailappversionoverrides" xsi:type="VersionOverridesV1_0">
-    <!-- The <Hosts> element is required for validation, but it is ignored when there there is a child <VersionOverrides> element of type VersionOverridesV1_1 with its own <Hosts> element. -->
-    <Hosts>
-      <Host xsi:type="MailHost">
-      </Host>
-    </Hosts>
     <VersionOverrides xmlns="http://schemas.microsoft.com/office/mailappversionoverrides/1.1" xsi:type="VersionOverridesV1_1">
       <Requirements>
         <bt:Sets DefaultMinVersion="1.3">


### PR DESCRIPTION
**Change Description**:

Remove a Hosts element from the Outlook XML manifest's VersionOverrides v. 1_0 because its presence caused a sideload failure on Old Outlook. 

1. **Do these changes impact any *npm scripts* commands (in package.json)?** (e.g., running 'npm run start')
    If Yes, briefly describe what is impacted.
no

2. **Do these changes impact *VS Code debugging* options (launch.json)?**
    If Yes, briefly describe what is impacted.
no

3. **Do these changes impact *template output*?** (e.g., add/remove file, update file location, update file contents)
    If Yes, briefly describe what is impacted.
Yes. See above.

4. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    If Yes, briefly describe what is impacted.
No.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:

All tests passed locally.
